### PR TITLE
update secp256k1 package to use `0.1.7`

### DIFF
--- a/Example/DSNPWalletExample/DSNPWalletExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/DSNPWalletExample/DSNPWalletExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
         "state": {
           "branch": null,
-          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
-          "version": "0.1.4"
+          "revision": "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
+          "version": "0.1.7"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/Bip39.swift.git", from: "0.1.1"),
         .package(url: "https://github.com/evgenyneu/keychain-swift.git", branch: "master"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.0.0")),
-        .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.4")),
+        .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.7")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
# Update the `secp256k1`

-  `secp256k1` dependency to use version `0.1.7`
-  This resolves a warning when building version `0.1.4`, 
-  May solve simulator building issues concerning this dependency

Before: 

<img width="584" alt="Screenshot 2023-04-26 at 3 55 59 PM" src="https://user-images.githubusercontent.com/5061628/234688097-8158db7d-18d1-4f5b-a3bb-dad07f654631.png">


After: 

<img width="578" alt="Screenshot 2023-04-26 at 3 56 16 PM" src="https://user-images.githubusercontent.com/5061628/234688149-84cf7946-8087-4539-83ff-2514ceeddd94.png">

The Warning: 

<img width="1122" alt="Screenshot 2023-04-26 at 3 57 12 PM" src="https://user-images.githubusercontent.com/5061628/234688351-0a3944d3-09a1-4a6e-8ed6-94a6a97b508e.png">

